### PR TITLE
Fixes bug where cursor gets lost

### DIFF
--- a/.idea/Menu.iml
+++ b/.idea/Menu.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.6 (dfl)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="TestRunnerService">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.6" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.6 (dfl)" project-jdk-type="Python SDK" />
 </project>

--- a/menu.py
+++ b/menu.py
@@ -74,7 +74,7 @@ def decode_keys(code, selected, search, len_bats):
     return [selected, search]
 
 
-def display_bats(all_bats, selected, search):
+def display_bats(all_bats, selected, search, stdscr):
     height, width = stdscr.getmaxyx()
     center_y = int(height / 2)
     terms = search.split(' ')
@@ -110,7 +110,7 @@ def exec_bat_file(bats, selected):
 
 
 def run_menu():
-    global stdscr
+    # global stdscr
     while True:
         with Screen() as stdscr:
             stdscr.erase()
@@ -119,7 +119,7 @@ def run_menu():
             selected = 0
             search = ""
             while search != 'X':
-                bats = display_bats(all_bats, selected, search)
+                bats = display_bats(all_bats, selected, search, stdscr)
                 code = stdscr.getch()
                 [selected, search] = decode_keys(code, selected, search, len(bats))
         # sums = get_sum()
@@ -129,5 +129,5 @@ def run_menu():
 
 
 if __name__ == "__main__":
-    stdscr = None
+    # stdscr = None
     run_menu()

--- a/menu.py
+++ b/menu.py
@@ -2,10 +2,8 @@ import sys
 import os
 import natsort
 import curses
-import datetime
 import menu_runner
 from pathlib import Path
-# from BatchLogger import update_stats, log, get_sum
 from menu_logger import log
 
 # set dfl_root to location of .bat files
@@ -53,7 +51,7 @@ def get_bats():
 
 
 # takes keyboard input and returns the file selected and search string
-def decode_keys(code, selected, search, len_all_bats):
+def decode_keys(code, selected, search, len_bats):
     key = curses.keyname(code).decode()
     if code == 10 or code == 343:
         # ENTER - run the selected batch file
@@ -61,14 +59,16 @@ def decode_keys(code, selected, search, len_all_bats):
     elif code == 27:
         # ESC - exit the menu
         raise SystemExit
-    elif code == curses.KEY_DOWN and selected < len_all_bats - 1:
+    elif code == curses.KEY_DOWN and selected < len_bats - 1:
         selected += 1
     elif code == curses.KEY_UP and selected > 0:
         selected -= 1
     elif key.lower() in "abcdefghijklmnopqrstuvwxyz.-()_ 1234567890":
+        # searching, so reposition the cursor
         search += key.lower()
         selected = 0
     elif key == "^?" or key == "KEY_BACKSPACE":
+        # searching, so reposition the cursor
         search = search[:-1]
         selected = 0
     return [selected, search]
@@ -121,7 +121,7 @@ def run_menu():
             while search != 'X':
                 bats = display_bats(all_bats, selected, search)
                 code = stdscr.getch()
-                [selected, search] = decode_keys(code, selected, search, len(all_bats))
+                [selected, search] = decode_keys(code, selected, search, len(bats))
         # sums = get_sum()
         # start = datetime.datetime.now()
         exec_bat_file(bats, selected)

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -19,47 +19,47 @@ def test_get_bats(fs):
 
 # ensure '2)' displays before '10)'
 def test_display_bats_sorted():
-    menu.stdscr = Mock()
-    menu.stdscr.getmaxyx.return_value = [40, 80]
+    stdscr = Mock()
+    stdscr.getmaxyx.return_value = [40, 80]
     all_bats = ['1) test', '2) XSeg - edit', '10) XSeg - apply']
     selected = 0
     search = ''
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == ['1) test', '2) XSeg - edit', '10) XSeg - apply']
 
 
 # test searching a single word
 def test_display_bats_search_word():
-    menu.stdscr = Mock()
-    menu.stdscr.getmaxyx.return_value = [40, 80]
+    stdscr = Mock()
+    stdscr.getmaxyx.return_value = [40, 80]
     all_bats = ['1) test', '2) XSeg - edit', '10) XSeg - apply']
     selected = 0
     search = 'xs'
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == ['2) XSeg - edit', '10) XSeg - apply']
 
 
 # test searching for multiple words
 def test_display_bats_search_multiple_words():
-    menu.stdscr = Mock()
-    menu.stdscr.getmaxyx.return_value = [40, 80]
+    stdscr = Mock()
+    stdscr.getmaxyx.return_value = [40, 80]
     all_bats = ['1) test', '2) XSeg - edit', '10) XSeg - apply']
     selected = 0
     search = 'xs ed'
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == ['2) XSeg - edit']
 
 
 # ensure default display is correct
 def test_display_bats_text():
-    menu.stdscr = Mock()
-    menu.stdscr.getmaxyx.return_value = [40, 80]
+    stdscr = Mock()
+    stdscr.getmaxyx.return_value = [40, 80]
     all_bats = ['1) test', '2) XSeg - edit', '10) XSeg - apply']
     selected = 0
     search = ''
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == ['1) test', '2) XSeg - edit', '10) XSeg - apply']
-    result = str(menu.stdscr.method_calls).split('call.')
+    result = str(stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
     assert len(result) == 8
     assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
@@ -71,14 +71,14 @@ def test_display_bats_text():
 
 # ensure files move up and are correctly highlighted when selected changes
 def test_display_bats_down_one():
-    menu.stdscr = Mock()
-    menu.stdscr.getmaxyx.return_value = [40, 80]
+    stdscr = Mock()
+    stdscr.getmaxyx.return_value = [40, 80]
     all_bats = ['1) test', '2) XSeg - edit', '10) XSeg - apply']
     selected = 1
     search = ''
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == ['1) test', '2) XSeg - edit', '10) XSeg - apply']
-    result = str(menu.stdscr.method_calls).split('call.')
+    result = str(stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
     assert len(result) == 8
     assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
@@ -90,14 +90,14 @@ def test_display_bats_down_one():
 
 # ensure long file names are ok
 def test_display_bats_long_names():
-    menu.stdscr = Mock()
-    menu.stdscr.getmaxyx.return_value = [40, 80]
+    stdscr = Mock()
+    stdscr.getmaxyx.return_value = [40, 80]
     all_bats = ['1) test of a really really really long file name', '2) XSeg - edit', '10) XSeg - apply']
     selected = 1
     search = ''
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == ['1) test of a really really really long file name', '2) XSeg - edit', '10) XSeg - apply']
-    result = str(menu.stdscr.method_calls).split('call.')
+    result = str(stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
     assert len(result) == 8
     assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
@@ -109,14 +109,14 @@ def test_display_bats_long_names():
 
 # ensure long file names are truncated if screen is too small
 def test_display_bats_truncated_long_names():
-    menu.stdscr = Mock()
-    menu.stdscr.getmaxyx.return_value = [40, 30]
+    stdscr = Mock()
+    stdscr.getmaxyx.return_value = [40, 30]
     all_bats = ['1) test of a really really really long file name', '2) XSeg - edit', '10) XSeg - apply']
     selected = 1
     search = ''
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == ['1) test of a really really really long file name', '2) XSeg - edit', '10) XSeg - apply']
-    result = str(menu.stdscr.method_calls).split('call.')
+    result = str(stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
     assert len(result) == 8
     assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
@@ -128,8 +128,8 @@ def test_display_bats_truncated_long_names():
 
 # fix known curses error when printing to last character of bottom row
 def test_display_bats_curses_error():
-    menu.stdscr = Mock()
-    menu.stdscr.getmaxyx.return_value = [20, 46]
+    stdscr = Mock()
+    stdscr.getmaxyx.return_value = [20, 46]
     all_bats = [
         '1) test of a really really really long file name',
         '2) XSeg - edit',
@@ -145,9 +145,9 @@ def test_display_bats_curses_error():
     ]
     selected = 0
     search = ''
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == all_bats
-    result = str(menu.stdscr.method_calls).split('call.')
+    result = str(stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
     assert len(result) == 15
     assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
@@ -166,8 +166,8 @@ def test_display_bats_curses_error():
 
 # ensure top line is not over written
 def test_display_bats_top_line_bug():
-    menu.stdscr = Mock()
-    menu.stdscr.getmaxyx.return_value = [20, 40]
+    stdscr = Mock()
+    stdscr.getmaxyx.return_value = [20, 40]
     all_bats = [
         '1) test of a really really really long file name',
         '2) XSeg - edit',
@@ -198,9 +198,9 @@ def test_display_bats_top_line_bug():
     ]
     selected = 10
     search = ''
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == all_bats
-    result = str(menu.stdscr.method_calls).split('call.')
+    result = str(stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
     assert len(result) == 23
     assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
@@ -227,8 +227,8 @@ def test_display_bats_top_line_bug():
 
 # ensure cursor doesn't go below the bottom of the list of bats
 def test_display_bats_cursor_disappears_bug():
-    menu.stdscr = Mock()
-    menu.stdscr.getmaxyx.return_value = [20, 40]
+    stdscr = Mock()
+    stdscr.getmaxyx.return_value = [20, 40]
     all_bats = [
         '1) test',
         '2) test',
@@ -239,16 +239,16 @@ def test_display_bats_cursor_disappears_bug():
     curses.initscr()
     selected = 0
     search = '4'
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == ['4) test']
     code = curses.KEY_DOWN
     search = '4'
     [selected, search] = menu.decode_keys(code, selected, search, len(bats))
     assert search == '4'
     assert selected == 0
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == ['4) test']
-    result = str(menu.stdscr.method_calls).split('call.')
+    result = str(stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
     assert len(result) == 11
     assert result[10] == "addstr(10, 1, '4) test', 65536)]"
@@ -256,8 +256,8 @@ def test_display_bats_cursor_disappears_bug():
 
 # ensure searching for garbage results in the empty set of files
 def test_display_bats_nothing_found():
-    menu.stdscr = Mock()
-    menu.stdscr.getmaxyx.return_value = [20, 40]
+    stdscr = Mock()
+    stdscr.getmaxyx.return_value = [20, 40]
     all_bats = [
         '1) test',
         '2) test',
@@ -268,9 +268,9 @@ def test_display_bats_nothing_found():
     curses.initscr()
     selected = 0
     search = 'q'
-    bats = menu.display_bats(all_bats, selected, search)
+    bats = menu.display_bats(all_bats, selected, search, stdscr)
     assert bats == []
-    result = str(menu.stdscr.method_calls).split('call.')
+    result = str(stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
     assert len(result) == 5
     assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,10 +1,7 @@
-import os
 from pathlib import Path
-import unittest.mock
 from unittest.mock import Mock
 import pytest
 import menu
-import pyfakefs
 import curses
 
 
@@ -62,20 +59,14 @@ def test_display_bats_text():
     search = ''
     bats = menu.display_bats(all_bats, selected, search)
     assert bats == ['1) test', '2) XSeg - edit', '10) XSeg - apply']
-    result = str(menu.stdscr.method_calls).split(',')
+    result = str(menu.stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
-    assert 22 == len(result)
-    assert result[4] == "'Select .bat File to Run'"
-    assert result[8] == "'(type to search)'"
-    assert result[10] == "call.addstr(20"
-    assert result[12] == "'1) test'"
-    assert result[13] == "65536)"
-    assert result[14] == "call.addstr(21"
-    assert result[16] == "'2) XSeg - edit'"
-    assert result[17] == "0)"
-    assert result[18] == "call.addstr(22"
-    assert result[20] == "'10) XSeg - apply'"
-    assert result[21] == "0)]"
+    assert len(result) == 8
+    assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
+    assert result[4] == "addstr(1, 25, '(type to search)', 0),"
+    assert result[5] == "addstr(20, 1, '1) test', 65536),"
+    assert result[6] == "addstr(21, 1, '2) XSeg - edit', 0),"
+    assert result[7] == "addstr(22, 1, '10) XSeg - apply', 0)]"
 
 
 # ensure files move up and are correctly highlighted when selected changes
@@ -87,20 +78,14 @@ def test_display_bats_down_one():
     search = ''
     bats = menu.display_bats(all_bats, selected, search)
     assert bats == ['1) test', '2) XSeg - edit', '10) XSeg - apply']
-    result = str(menu.stdscr.method_calls).split(',')
+    result = str(menu.stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
-    assert 22 == len(result)
-    assert result[4] == "'Select .bat File to Run'"
-    assert result[8] == "'(type to search)'"
-    assert result[10] == "call.addstr(19"
-    assert result[12] == "'1) test'"
-    assert result[13] == "0)"
-    assert result[14] == "call.addstr(20"
-    assert result[16] == "'2) XSeg - edit'"
-    assert result[17] == "65536)"
-    assert result[18] == "call.addstr(21"
-    assert result[20] == "'10) XSeg - apply'"
-    assert result[21] == "0)]"
+    assert len(result) == 8
+    assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
+    assert result[4] == "addstr(1, 25, '(type to search)', 0),"
+    assert result[5] == "addstr(19, 1, '1) test', 0),"
+    assert result[6] == "addstr(20, 1, '2) XSeg - edit', 65536),"
+    assert result[7] == "addstr(21, 1, '10) XSeg - apply', 0)]"
 
 
 # ensure long file names are ok
@@ -112,20 +97,14 @@ def test_display_bats_long_names():
     search = ''
     bats = menu.display_bats(all_bats, selected, search)
     assert bats == ['1) test of a really really really long file name', '2) XSeg - edit', '10) XSeg - apply']
-    result = str(menu.stdscr.method_calls).split(',')
+    result = str(menu.stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
-    assert 22 == len(result)
-    assert result[4] == "'Select .bat File to Run'"
-    assert result[8] == "'(type to search)'"
-    assert result[10] == "call.addstr(19"
-    assert result[12] == "'1) test of a really really really long file name'"
-    assert result[13] == "0)"
-    assert result[14] == "call.addstr(20"
-    assert result[16] == "'2) XSeg - edit'"
-    assert result[17] == "65536)"
-    assert result[18] == "call.addstr(21"
-    assert result[20] == "'10) XSeg - apply'"
-    assert result[21] == "0)]"
+    assert len(result) == 8
+    assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
+    assert result[4] == "addstr(1, 25, '(type to search)', 0),"
+    assert result[5] == "addstr(19, 1, '1) test of a really really really long file name', 0),"
+    assert result[6] == "addstr(20, 1, '2) XSeg - edit', 65536),"
+    assert result[7] == "addstr(21, 1, '10) XSeg - apply', 0)]"
 
 
 # ensure long file names are truncated if screen is too small
@@ -137,20 +116,14 @@ def test_display_bats_truncated_long_names():
     search = ''
     bats = menu.display_bats(all_bats, selected, search)
     assert bats == ['1) test of a really really really long file name', '2) XSeg - edit', '10) XSeg - apply']
-    result = str(menu.stdscr.method_calls).split(',')
+    result = str(menu.stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
-    assert 22 == len(result)
-    assert result[4] == "'Select .bat File to Run'"
-    assert result[8] == "'(type to search)'"
-    assert result[10] == "call.addstr(19"
-    assert result[12] == "'1) test of a really really..'"
-    assert result[13] == "0)"
-    assert result[14] == "call.addstr(20"
-    assert result[16] == "'2) XSeg - edit'"
-    assert result[17] == "65536)"
-    assert result[18] == "call.addstr(21"
-    assert result[20] == "'10) XSeg - apply'"
-    assert result[21] == "0)]"
+    assert len(result) == 8
+    assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
+    assert result[4] == "addstr(1, 25, '(type to search)', 0),"
+    assert result[5] == "addstr(19, 1, '1) test of a really really..', 0),"
+    assert result[6] == "addstr(20, 1, '2) XSeg - edit', 65536),"
+    assert result[7] == "addstr(21, 1, '10) XSeg - apply', 0)]"
 
 
 # fix known curses error when printing to last character of bottom row
@@ -168,33 +141,27 @@ def test_display_bats_curses_error():
         '4.3) test of a really really really long file name',
         '4.4) test of a really really really long file name',
         '4.5) test write to bottom line last character',
-        '4.6) test of a really really really long file name',
-        '4.7) test of a really really really long file name',
-        '4.8) test of a really really really long file name',
-        '4.9) test of a really really really long file name',
-        '5) test',
-        '6.1) test',
-        '6.2) test',
-        '6.3) test',
-        '6.4) test',
-        '6.5) test',
-        '6.6) test',
-        '6.7) test',
-        '7) test',
-        '8) test',
-        '9) test',
-        '10) XSeg - apply'
+        '4.6) test of a really really really long file name'
     ]
     selected = 0
     search = ''
     bats = menu.display_bats(all_bats, selected, search)
     assert bats == all_bats
-    result = str(menu.stdscr.method_calls).split(',')
+    result = str(menu.stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
-    assert 50 == len(result)
-    assert result[46] == "call.addstr(19"
-    assert result[48] == "'4.5) test write to bottom line last charac..'"
-    assert result[49] == "0)]"
+    assert len(result) == 15
+    assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
+    assert result[4] == "addstr(1, 25, '(type to search)', 0),"
+    assert result[5] == "addstr(10, 1, '1) test of a really really really long fil..', 65536),"
+    assert result[6] == "addstr(11, 1, '2) XSeg - edit', 0),"
+    assert result[7] == "addstr(12, 1, '3.1) test', 0),"
+    assert result[8] == "addstr(13, 1, '3.2) test', 0),"
+    assert result[9] == "addstr(14, 1, '3.3) test', 0),"
+    assert result[10] == "addstr(15, 1, '4.1) test of another really really really ..', 0),"
+    assert result[11] == "addstr(16, 1, '4.2) test of yet another really really rea..', 0),"
+    assert result[12] == "addstr(17, 1, '4.3) test of a really really really long f..', 0),"
+    assert result[13] == "addstr(18, 1, '4.4) test of a really really really long f..', 0),"
+    assert result[14] == "addstr(19, 1, '4.5) test write to bottom line last charac..', 0)]"
 
 
 # ensure top line is not over written
@@ -233,13 +200,81 @@ def test_display_bats_top_line_bug():
     search = ''
     bats = menu.display_bats(all_bats, selected, search)
     assert bats == all_bats
-    result = str(menu.stdscr.method_calls).split(',')
+    result = str(menu.stdscr.method_calls).split('call.')
     result = list(map(str.strip, result))
-    assert 82 == len(result)
-    # assert '' == result
-    assert result[10] == "call.addstr(2"
-    assert result[12] == "'3.1) test'"
-    assert result[13] == "0)"
+    assert len(result) == 23
+    assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
+    assert result[4] == "addstr(1, 25, '(type to search)', 0),"
+    assert result[5] == "addstr(2, 1, '3.1) test', 0),"
+    assert result[6] == "addstr(3, 1, '3.2) test', 0),"
+    assert result[7] == "addstr(4, 1, '3.3) test', 0),"
+    assert result[8] == "addstr(5, 1, '4.1) test of another really really r..', 0),"
+    assert result[9] == "addstr(6, 1, '4.2) test of yet another really real..', 0),"
+    assert result[10] == "addstr(7, 1, '4.3) test of a really really really ..', 0),"
+    assert result[11] == "addstr(8, 1, '4.4) test of a really really really ..', 0),"
+    assert result[12] == "addstr(9, 1, '4.5) test write to bottom line last ..', 0),"
+    assert result[13] == "addstr(10, 1, '4.6) test of a really really really ..', 65536),"
+    assert result[14] == "addstr(11, 1, '4.7) test of a really really really ..', 0),"
+    assert result[15] == "addstr(12, 1, '4.8) test of a really really really ..', 0),"
+    assert result[16] == "addstr(13, 1, '4.9) test of a really really really ..', 0),"
+    assert result[17] == "addstr(14, 1, '5) test', 0),"
+    assert result[18] == "addstr(15, 1, '6.1) test', 0),"
+    assert result[19] == "addstr(16, 1, '6.2) test', 0),"
+    assert result[20] == "addstr(17, 1, '6.3) test', 0),"
+    assert result[21] == "addstr(18, 1, '6.4) test', 0),"
+    assert result[22] == "addstr(19, 1, '6.5) test', 0)]"
+
+
+# ensure cursor doesn't go below the bottom of the list of bats
+def test_display_bats_cursor_disappears_bug():
+    menu.stdscr = Mock()
+    menu.stdscr.getmaxyx.return_value = [20, 40]
+    all_bats = [
+        '1) test',
+        '2) test',
+        '3) test',
+        '4) test',
+        '5) test'
+    ]
+    curses.initscr()
+    selected = 0
+    search = '4'
+    bats = menu.display_bats(all_bats, selected, search)
+    assert bats == ['4) test']
+    code = curses.KEY_DOWN
+    search = '4'
+    [selected, search] = menu.decode_keys(code, selected, search, len(bats))
+    assert search == '4'
+    assert selected == 0
+    bats = menu.display_bats(all_bats, selected, search)
+    assert bats == ['4) test']
+    result = str(menu.stdscr.method_calls).split('call.')
+    result = list(map(str.strip, result))
+    assert len(result) == 11
+    assert result[10] == "addstr(10, 1, '4) test', 65536)]"
+
+
+# ensure searching for garbage results in the empty set of files
+def test_display_bats_nothing_found():
+    menu.stdscr = Mock()
+    menu.stdscr.getmaxyx.return_value = [20, 40]
+    all_bats = [
+        '1) test',
+        '2) test',
+        '3) test',
+        '4) test',
+        '5) test'
+    ]
+    curses.initscr()
+    selected = 0
+    search = 'q'
+    bats = menu.display_bats(all_bats, selected, search)
+    assert bats == []
+    result = str(menu.stdscr.method_calls).split('call.')
+    result = list(map(str.strip, result))
+    assert len(result) == 5
+    assert result[3] == "addstr(1, 1, 'Select .bat File to Run', 2228224),"
+    assert result[4] == "addstr(1, 25, 'q', 0)]"
 
 
 def test_decode_keys_enter():
@@ -264,7 +299,7 @@ def test_decode_keys_esc():
     len_all_bats = 5
     code = 27
     with pytest.raises(SystemExit):
-        [selected, search] = menu.decode_keys(code, selected, search, len_all_bats)
+        menu.decode_keys(code, selected, search, len_all_bats)
 
 
 def test_decode_keys_down():
@@ -323,7 +358,7 @@ def test_decode_keys_backspace():
     [selected, search] = menu.decode_keys(code, selected, search, len_all_bats)
     assert selected == 0
     assert search == 'jo'
-    # re-run, to test appending to search
+    # re-run, to test erasing from search
     code = curses.KEY_BACKSPACE
     [selected, search] = menu.decode_keys(code, selected, search, len_all_bats)
     assert selected == 0


### PR DESCRIPTION
When searching for batch files, the cursor was allowed to
drop below the number of files remaining after the search.
The issue was len(all_bats) into decode_keys().  The correct
response is to send len(bats)

Resolves: #3